### PR TITLE
ensure that socket is a single available instance

### DIFF
--- a/packages/core/lib/socket.d.ts
+++ b/packages/core/lib/socket.d.ts
@@ -1,4 +1,4 @@
-export declare function initSocket(isHTTPS?: boolean): Promise<void>;
+export declare function getSocket(isHTTPS?: boolean): Promise<void>;
 export declare function isSocketConnected(): any;
 export declare function sendSocketMessage(message: any): void;
 //# sourceMappingURL=socket.d.ts.map

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,7 @@ import {
   setEncryptionOverride,
 } from './messageEncryption';
 
-import { initSocket } from './socket';
+import { getSocket } from './socket';
 
 import * as utils from './utils';
 
@@ -29,8 +29,7 @@ if (isBrowser) {
 }
 
 if (!o3dapiCore.isAvailable) {
-  initSocket()
-  .catch(err => {});
+  getSocket().catch(err => {});
 }
 
 o3dapiCore.openO3 = () => window.location.replace('o3network://deep');

--- a/packages/core/src/messages.ts
+++ b/packages/core/src/messages.ts
@@ -10,7 +10,7 @@ import {
   AddEventsListenerArgs,
   SendMessageArgs,
 } from './types';
-import { isSocketConnected, sendSocketMessage, initSocket } from './socket';
+import { isSocketConnected, sendSocketMessage, getSocket } from './socket';
 
 const PLATFORM = 'o3-dapi';
 const messageQueue = {};
@@ -81,7 +81,6 @@ export function addEventsListener({blockchain, callback}: AddEventsListenerArgs)
   eventsListeners[blockchain] = callback;
 }
 
-let socketInitPromise;
 export function sendMessage({
   blockchain,
   version,
@@ -133,11 +132,7 @@ export function sendMessage({
         reject(NO_PROVIDER);
       }
     } else {
-      socketInitPromise = socketInitPromise || initSocket();
-
-      socketInitPromise
-      .then(() => {
-        socketInitPromise = null;
+      getSocket().then(() => {
         sendSocketMessage(message);
         messageQueue[messageId] = {
           resolve,
@@ -149,7 +144,6 @@ export function sendMessage({
         };
       })
       .catch(err => {
-        socketInitPromise = null;
         reject(NO_PROVIDER);
       });
     }


### PR DESCRIPTION
When I call the getProvider method, there are two socket instances.