### PR TITLE
fix testbed website socket disconnect problem

### DIFF
--- a/packages/neo/test/main.js
+++ b/packages/neo/test/main.js
@@ -209,10 +209,6 @@ neoDapi.addEventListener(neoDapi.Constants.EventName.DISCONNECTED, data => {
 
 neoDapi.addEventListener(neoDapi.Constants.EventName.NETWORK_CHANGED, handleNewNetworks);
 
-neoDapi.addEventListener(neoDapi.Constants.EventName.BLOCK_HEIGHT_CHANGED, data => {
-  console.log('neo block height changed: ', JSON.stringify(data));
-});
-
 neoDapi.addEventListener(neoDapi.Constants.EventName.TRANSACTION_CONFIRMED, data => {
   console.log('neo tx confirmed: ', JSON.stringify(data));
 });
@@ -235,4 +231,7 @@ function handleNewNetworks({networks, defaultNetwork}) {
 function onReady() {
   neoDapi.getNetworks()
   .then(handleNewNetworks);
+  neoDapi.addEventListener(neoDapi.Constants.EventName.BLOCK_HEIGHT_CHANGED, data => {
+    console.log('neo block height changed: ', JSON.stringify(data));
+  });
 };


### PR DESCRIPTION
The reason is: while adding event listener for event "BLOCK_HEIGHT_CHANGED",  the logic will setup another socket to listen to the height update, if this is added before `READY` event, it will cause the other socket disconnect again and again. I don't know the exact reason, but it seems they mixed up.